### PR TITLE
convert the time and date bytes to unix epoch ms

### DIFF
--- a/node_stream_zip.js
+++ b/node_stream_zip.js
@@ -668,9 +668,9 @@ function parse_zip_time(timebytes, datebytes) {
     var datebits = bits(datebytes, 16);
 
     var mt = {
-        h: parseInt(timebits.slice(0,5).join(''), 2) * 2,
+        h: parseInt(timebits.slice(0,5).join(''), 2),
         m: parseInt(timebits.slice(5,11).join(''), 2),
-        s: parseInt(timebits.slice(11,16).join(''), 2),
+        s: parseInt(timebits.slice(11,16).join(''), 2) * 2,
         Y: parseInt(datebits.slice(0,7).join(''), 2) + 1980,
         M: parseInt(datebits.slice(7,11).join(''), 2),
         D: parseInt(datebits.slice(11,16).join(''), 2),


### PR DESCRIPTION
i noticed the date and time fields of files on all entries were simply being read out flat, but that the specification for zip file headers has a specific bit packing to determine the actual timestamp values. since i needed these modification times, it seemed like the most useful approach (and a pretty reasonable one) was to alter the module to perform that parsing

i was guided by the following information [located here](https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html)

File modification time | stored in standard MS-DOS format:
Bits 00-04: seconds divided by 2 
Bits 05-10: minute
Bits 11-15: hour

File modification date | stored in standard MS-DOS format:
Bits 00-04: day
Bits 05-08: month
Bits 09-15: years from 1980

there may be other ways you'd prefer to unpack these bits, or to expose a parsed time through this module, but this code can serve as a proof of concept for how to convert the 32-bit (actually two 16-bit) date/time byte fields to a useful format

thanks!