### PR TITLE
fixed close() when zip was not found

### DIFF
--- a/node_stream_zip.js
+++ b/node_stream_zip.js
@@ -578,7 +578,8 @@ var StreamZip = function(config) {
     };
 
     this.close = function(callback) {
-        if (closed) {
+        if (closed || !fd) {
+            closed = true;
             if (callback)
                 callback();
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-stream-zip",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-stream-zip",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "node.js library for reading and extraction of ZIP archives",
   "keywords": [
     "zip",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,8 @@
 Release notes
 -------------
+##### v1.9.2 (2020-04-28)
+`-` fixed close() when zip was not found
+
 ##### v1.9.1 (2020-01-14)
 `-` fixed callbacks in close()
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -255,6 +255,21 @@ module.exports.error['evil.zip'] = function(test) {
     });
 };
 
+module.exports.error['zip does not exist'] = function(test) {
+    test.expect(1);
+    var zip = new StreamZip({ file: 'test/err/doesnotexist.zip' });
+    zip.on('ready', function() {
+        test.ok(false, 'Should throw an error');
+    });
+    zip.on('error', function(err) {
+        test.equal(err.message, "ENOENT: no such file or directory, open 'test/err/doesnotexist.zip'");
+
+        try { zip.close(); } catch (e) { test.ok(false, 'zip.close() should not throw: ' + e); }
+
+        test.done();
+    });
+};
+
 module.exports.parallel = {};
 module.exports.parallel['streaming 100 files'] = function(test) {
     var num = 100;


### PR DESCRIPTION
Noticed that if I called `close` on a zip that did not open, due to the path being incorrect, the code threw the following

    (node:1982) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "fd" argument must be of type number. Received type undefined
        at Object.close (fs.js:392:3)
        at StreamZip.close (/Users/user/Development/app/test-scripts/node_modules/node-stream-zip/node_stream_zip.js:586:16)
        at Object.module.exports.assertZip (/Users/user/Development/app/test-scripts/js/assertZip.js:38:35)
