### PR TITLE
removed deflate64

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features:
 - fast initialization
 - no dependencies, no binary addons
 - decompression with built-in zlib module
-- deflate, deflate64, sfx, macosx/windows built-in archives
+- deflate, sfx, macosx/windows built-in archives
 - ZIP64 support
 
 # Installation


### PR DESCRIPTION
Since you do not support deflate64 either, I removed it from the Readme to avoid further misconceptions.