### PR TITLE
fix some typedefs related to entries

### DIFF
--- a/node_stream_zip.d.ts
+++ b/node_stream_zip.d.ts
@@ -134,9 +134,9 @@ declare module 'node-stream-zip' {
         on(event: 'ready', handler: () => void): void
         on(event: 'extract', handler: (entry: ZipEntry, outPath: string) => void): void
 
-        entry(name: string): ZipEntry
+        entry(name: string): ZipEntry | undefined
 
-        entries(): ZipEntry[]
+        entries(): { [name: string]: ZipEntry }
 
         stream(entry: string, callback: (err: any | null, stream?: NodeJS.ReadableStream) => void): void
 


### PR DESCRIPTION
1. entries() does not return an array
2. entry(string) may return undefined if there is no entry for that specific name.

There may be other related issues, these are just the two that I noticed.