### PR TITLE
Improved Typescript Type Definitions

### DIFF
--- a/node_stream_zip.d.ts
+++ b/node_stream_zip.d.ts
@@ -30,7 +30,7 @@ declare module 'node-stream-zip' {
             chunkSize?: number
         }
     
-        class ZipEntry {
+        interface ZipEntry {
             /**
              * file name
              */

--- a/node_stream_zip.d.ts
+++ b/node_stream_zip.d.ts
@@ -143,13 +143,13 @@ declare module 'node-stream-zip' {
 
         entries(): { [name: string]: ZipEntry }
 
-        stream(entry: string, callback: (err: any | null, stream?: NodeJS.ReadableStream) => void): void
+        stream(entry: string | ZipEntry, callback: (err: any | null, stream?: NodeJS.ReadableStream) => void): void
 
-        entryDataSync(entry: string): Buffer
+        entryDataSync(entry: string | ZipEntry): Buffer
 
-        openEntry(entry: string, callback: (err: any | null, entry?: ZipEntry) => void, sync: boolean): void
+        openEntry(entry: string | ZipEntry, callback: (err: any | null, entry?: ZipEntry) => void, sync: boolean): void
 
-        extract(entry: string | null, outPath: string, callback: (err?: any) => void): void
+        extract(entry: string | ZipEntry | null, outPath: string, callback: (err?: any) => void): void
 
         close(callback?: (err?: any) => void): void
     }

--- a/node_stream_zip.d.ts
+++ b/node_stream_zip.d.ts
@@ -2,119 +2,124 @@
 
 declare module 'node-stream-zip' {
 
-    interface StreamZipOptions {
-        /**
-         * File to read
-         */
-        file: string
-
-        /**
-         * You will be able to work with entries inside zip archive,
-         * otherwise the only way to access them is entry event
-         * @default true
-         */
-        storeEntries?: boolean
-
-        /**
-         * By default, entry name is checked for malicious characters, like ../ or c:\123,
-         * pass this flag to disable validation error
-         * @default false
-         */
-        skipEntryNameValidation?: boolean
-
-        /**
-         * Filesystem read chunk size
-         * @default automatic based on file size
-         */
-        chunkSize?: number
+    namespace StreamZip {
+        interface StreamZipOptions {
+            /**
+             * File to read
+             */
+            file: string
+    
+            /**
+             * You will be able to work with entries inside zip archive,
+             * otherwise the only way to access them is entry event
+             * @default true
+             */
+            storeEntries?: boolean
+    
+            /**
+             * By default, entry name is checked for malicious characters, like ../ or c:\123,
+             * pass this flag to disable validation error
+             * @default false
+             */
+            skipEntryNameValidation?: boolean
+    
+            /**
+             * Filesystem read chunk size
+             * @default automatic based on file size
+             */
+            chunkSize?: number
+        }
+    
+        class ZipEntry {
+            /**
+             * file name
+             */
+            name: string
+    
+            /**
+             * true if it's a directory entry
+             */
+            isDirectory: boolean
+    
+            /**
+             * true if it's a file entry, see also isDirectory
+             */
+            isFile: boolean
+    
+            /**
+             * file comment
+             */
+            comment: string
+    
+            /**
+             * if the file is encrypted
+             */
+            encrypted: boolean
+    
+            /**
+             * version made by
+             */
+            verMade: number
+    
+            /**
+             * version needed to extract
+             */
+            version: number
+    
+            /**
+             * encrypt, decrypt flags
+             */
+            flags: number
+    
+            /**
+             * compression method
+             */
+            method: number
+    
+            /**
+             * modification time
+             */
+            time: number
+    
+            /**
+             * uncompressed file crc-32 value
+             */
+            crc: number
+    
+            /**
+             * compressed size
+             */
+            compressedSize: number
+    
+            /**
+             * uncompressed size
+             */
+            size: number
+    
+            /**
+             * volume number start
+             */
+            diskStart: number
+    
+            /**
+             * internal file attributes
+             */
+            inattr: number
+    
+            /**
+             * external file attributes
+             */
+            attr: number
+    
+            /**
+             * LOC header offset
+             */
+            offset: number
+        }
     }
 
-    class ZipEntry {
-        /**
-         * file name
-         */
-        name: string
-
-        /**
-         * true if it's a directory entry
-         */
-        isDirectory: boolean
-
-        /**
-         * true if it's a file entry, see also isDirectory
-         */
-        isFile: boolean
-
-        /**
-         * file comment
-         */
-        comment: string
-
-        /**
-         * if the file is encrypted
-         */
-        encrypted: boolean
-
-        /**
-         * version made by
-         */
-        verMade: number
-
-        /**
-         * version needed to extract
-         */
-        version: number
-
-        /**
-         * encrypt, decrypt flags
-         */
-        flags: number
-
-        /**
-         * compression method
-         */
-        method: number
-
-        /**
-         * modification time
-         */
-        time: number
-
-        /**
-         * uncompressed file crc-32 value
-         */
-        crc: number
-
-        /**
-         * compressed size
-         */
-        compressedSize: number
-
-        /**
-         * uncompressed size
-         */
-        size: number
-
-        /**
-         * volume number start
-         */
-        diskStart: number
-
-        /**
-         * internal file attributes
-         */
-        inattr: number
-
-        /**
-         * external file attributes
-         */
-        attr: number
-
-        /**
-         * LOC header offset
-         */
-        offset: number
-    }
+    type StreamZipOptions = StreamZip.StreamZipOptions;
+    type ZipEntry = StreamZip.ZipEntry;
 
     class StreamZip {
         constructor(config: StreamZipOptions);


### PR DESCRIPTION
I added the ZipEntry and StreamZipOption types to an ambient namespace so that they can be imported by consumers. Now users of the library can do:

```
import StreamZip = require('node-stream-zip');
import {ZipEntry} from 'node-stream-zip';
const zip = new StreamZip({file: tempFilePath, storeEntries: true});
zip.on('entry', (entry: ZipEntry) => {
...
});

```