### PR TITLE
Add missing 'declare' keyword to typescript definitions

### DIFF
--- a/node_stream_zip.d.ts
+++ b/node_stream_zip.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-namespace StreamZip {
+declare namespace StreamZip {
     interface StreamZipOptions {
         /**
          * File to read


### PR DESCRIPTION
Apologies for this issue!