### PR TITLE
Update node_stream_zip.d.ts

### DIFF
--- a/node_stream_zip.d.ts
+++ b/node_stream_zip.d.ts
@@ -133,7 +133,7 @@ declare class StreamZipAsync {
     comment: Promise<string>;
 
     entry(name: string): Promise<ZipEntry | undefined>;
-    entries(name: string): Promise<{ [name: string]: ZipEntry }>;
+    entries(): Promise<{ [name: string]: ZipEntry }>;
     entryData(entry: string | ZipEntry): Promise<Buffer>;
     stream(entry: string | ZipEntry): Promise<NodeJS.ReadableStream>;
     extract(entry: string | ZipEntry | null, outPath: string): Promise<number | undefined>;


### PR DESCRIPTION
Fix typing for StreamZipAsync entries method

It does not have params in js:
https://github.com/antelle/node-stream-zip/blob/master/node_stream_zip.js#L701-L704