### PR TITLE
Fix for deregistering 'error' event on async init on node versions before v10.0.0

### DIFF
--- a/node_stream_zip.js
+++ b/node_stream_zip.js
@@ -678,7 +678,7 @@ StreamZip.async = class StreamZipAsync extends events.EventEmitter {
 
         this[propZip] = new Promise((resolve, reject) => {
             zip.on('ready', () => {
-                zip.off('error', reject);
+                zip.removeListener('error', reject);
                 resolve(zip);
             });
             zip.on('error', reject);


### PR DESCRIPTION
## Description
Using the library on node v8 got an error: `zip.off is not a function`.

**Root Cause:** `emitter.off(eventName, listener)` was not introduced until v10.0.0 (Source: https://nodejs.org/api/events.html#events_emitter_off_eventname_listener)

**Fix:** Use of `emitter.removeListener(eventName, listener)` instead of `emitter.off(eventName, listener)` (which is an alias of former)

## Tests 
### Manual test cases run
- Verified this fix to be working on node v8
- Verified existing specs to be working as expected.