### PR TITLE
Add setFs to types

### DIFF
--- a/node_stream_zip.d.ts
+++ b/node_stream_zip.d.ts
@@ -194,6 +194,8 @@ declare class StreamZip {
     close(callback?: (err?: any) => void): void;
 
     static async: typeof StreamZip.StreamZipAsync;
+    
+    static setFs(fsLike: any): void;
 }
 
 export = StreamZip;


### PR DESCRIPTION
Adds the `setFs` method which exists in js to the typescript types.